### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/lib/formatDetector.py
+++ b/lib/formatDetector.py
@@ -1,8 +1,15 @@
+from __future__ import print_function
 import angr
 import claripy
 import time
 import timeout_decorator
 import IPython
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 '''
 Model either printf("User input") or printf("%s","Userinput")
@@ -81,7 +88,7 @@ class printFormat(angr.procedures.libc.printf.printf):
                         
                         return True
                 if state_copy.globals['inputType'] == "ARG":
-                    arg = state.globals['arg']
+                    arg = state_copy.globals['arg']
                     arg_str = str(state_copy.solver.eval(arg,cast_to=str))
                     if str_val in arg_str:
                         var_value = self.state.memory.load(var_loc)
@@ -163,4 +170,3 @@ def checkFormat(binary_name,inputType="STDIN"):
 
 
     
-

--- a/lib/formatExploiter.py
+++ b/lib/formatExploiter.py
@@ -1,7 +1,9 @@
+from __future__ import print_function
+from __future__ import absolute_import
 import angr
 from pwn import *
-from formatDetector import printFormat
-from overflowExploiter import getShellcode,getRegValues,findShellcode
+from .formatDetector import printFormat
+from .overflowExploiter import getShellcode,getRegValues,findShellcode
 import timeout_decorator
 import time
 import string
@@ -79,11 +81,11 @@ def rediscoverAndExploit(binary_name,properties,stack_position):
     #Setup state based on input type
     argv = [binary_name]
     if inputType == "STDIN":
-	'''
-	angr doesn't use the right base and stack pointers
-	when loading the binary, so our addresses are all wrong.
-	So we need to grab them manually
-	'''
+        '''
+        angr doesn't use the right base and stack pointers
+        when loading the binary, so our addresses are all wrong.
+        So we need to grab them manually
+        '''
         entryAddr = p.loader.main_object.entry
         reg_values = getRegValues(binary_name,entryAddr)
         state = p.factory.full_init_state(args=argv)
@@ -515,4 +517,3 @@ def sendExploit(binary_name,properties,input_string,remote_server=False,remote_u
             pass
 
     return send_results
-

--- a/lib/formatLeak.py
+++ b/lib/formatLeak.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from pwn import *
 import binascii
 import string

--- a/lib/overflowDetector.py
+++ b/lib/overflowDetector.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import angr
 import claripy
 import time

--- a/lib/overflowExploitSender.py
+++ b/lib/overflowExploitSender.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from pwn import *
 
 def sendExploit(binary_name,properties,remote_server=False,remote_url="",port_num=0):

--- a/lib/overflowExploiter.py
+++ b/lib/overflowExploiter.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import angr
 import claripy
 import time
@@ -32,7 +33,7 @@ def getRopchain(properties,bad_bytes):
     'detailed' : False}
 
     rs = RopperService(options)
-    print properties['libc']
+    print(properties['libc'])
     if 'libc' in properties and properties['libc'] is not None:
         rs.addFile(properties['libc'])
     rs.addFile(properties['file'])
@@ -382,7 +383,7 @@ def pickFilter(simgr,properties):
             addresses = [x for x in find_symbolic_buffer(state_copy,len(shellcode))]
 
             for address in addresses:
-                print("[+] Found address at {}\r".format(hex(address))),
+                print(("[+] Found address at {}\r".format(hex(address))), end=' ')
                 state_copy = state.copy()
 
                 padded_addr = 0
@@ -579,7 +580,7 @@ def pickFilter(simgr,properties):
             addresses = [x for x in find_symbolic_buffer(state_copy,len(rop_chain))]
 
             for address in addresses:
-                print("[+] Found address at {}\r".format(hex(address))),
+                print(("[+] Found address at {}\r".format(hex(address))), end=' ')
                 state_copy = state.copy()
 
                 padded_addr = 0
@@ -749,8 +750,8 @@ def check_continuity(address, addresses, length):
     memory.
     '''
     for i in range(length):
-	if not address + i in addresses:
-	    return False
+        if not address + i in addresses:
+            return False
     return True
 
 def find_symbolic_buffer(state, length, arg=None):
@@ -761,15 +762,15 @@ def find_symbolic_buffer(state, length, arg=None):
     sym_addrs = []
     # get all the symbolic bytes from stdin
     if arg is not None:
-	for var in arg.variables:
-	    sym_addrs.extend(state.memory.addrs_for_name(var))
+        for var in arg.variables:
+            sym_addrs.extend(state.memory.addrs_for_name(var))
     else:
-	stdin_file = state.posix.get_file(0)
-	for var in stdin_file.variables():
-	    sym_addrs.extend(state.memory.addrs_for_name(var))
+        stdin_file = state.posix.get_file(0)
+    for var in stdin_file.variables():
+        sym_addrs.extend(state.memory.addrs_for_name(var))
     for addr in sym_addrs:
-	if check_continuity(addr, sym_addrs, length):
-	    yield addr
+        if check_continuity(addr, sym_addrs, length):
+            yield addr
 def getRegValues(filename,endAddr):
 
     r2 = r2pipe.open(filename)

--- a/lib/winFunctionDetector.py
+++ b/lib/winFunctionDetector.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import r2pipe
 import json
 import base64

--- a/zeratool.py
+++ b/zeratool.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import argparse
 import logging
 logging.disable(logging.CRITICAL)


### PR DESCRIPTION
Minimal, safe changes required to make this code syntax compatible with both Python 2 and Python 3. There will probably be more changes required to complete the port to Python 3 but this should provide a solid start in that process without breaking backward compatibility with legacy Python.

flake8 testing of https://github.com/ChrisTheCoolHut/Zeratool on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lib/formatDetector.py:23:18: F821 undefined name 'xrange'
        for i in xrange(5):
                 ^
./lib/formatDetector.py:36:96: F821 undefined name 'xrange'
            symbolic_list = [state_copy.memory.load(var_loc + x).get_byte(0).symbolic for x in xrange(var_value_length)]
                                                                                               ^
./lib/formatDetector.py:84:27: F821 undefined name 'state'
                    arg = state.globals['arg']
                          ^
./lib/formatExploiter.py:82:4: E999 TabError: inconsistent use of tabs and spaces in indentation
	'''
   ^
./lib/overflowExploiter.py:35:20: E999 SyntaxError: invalid syntax
    print properties['libc']
                   ^
2     E999 TabError: inconsistent use of tabs and spaces in indentation
3     F821 undefined name 'xrange'
5
```