### PR TITLE
Fix old dependencies and some other problems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo apt-get install python-pip python-dev build-essential rubygems-integration ruby-dev rubygems python-dev libffi-dev -y
+sudo apt-get install python-pip build-essential rubygems-integration ruby-dev rubygems python-dev libffi-dev pkg-config wget -y
 #Ubuntu 12 -> rubygems
 #Ubuntu 14 -> rubygems-integration
 #Ubuntu 16,18 -> ruby-dev
@@ -8,10 +8,9 @@ sudo dpkg --add-architecture i386
 sudo apt-get update
 sudo apt-get install libc6:i386 libstdc++6:i386 -y
 
- 
+sudo pip install --upgrade pip==19.0.0 
+
 sudo pip install virtualenv virtualenvwrapper
- 
-sudo pip install --upgrade pip
   
 printf '\n%s\n%s\n%s' '# virtualenv' 'export WORKON_HOME=~/virtualenvs' 'source /usr/local/bin/virtualenvwrapper.sh' >> ~/.bashrc
 
@@ -25,13 +24,13 @@ workon zeratool
 sudo gem install one_gadget
 
 #Need to port to latest angr
-pip install angr==7.8.2.21 cffi==1.7.0 future==0.16.0 pycparser==2.18  IPython==5.0 r2pipe psutil timeout_decorator pwn
+pip install angr==7.8.2.21 pwntools==3.13.0 ropper==1.13.6 cffi==1.7.0 future==0.16.0 pycparser==2.18  IPython==5.0 r2pipe==1.4.2 psutil==5.8.0 timeout_decorator==0.5.0
 
 git clone https://github.com/radare/radare2.git
 
-sudo ./radare2/sys/install.sh
-
-pip install IPython==5.0 r2pipe psutil timeout_decorator pwn
+cd radare2
+git checkout 5.1.0
+sudo ./sys/install.sh
 
 echo "####################"
 echo "run: . ~/.bashrc"

--- a/lib/inputDetector.py
+++ b/lib/inputDetector.py
@@ -7,6 +7,8 @@ libpwnable = "LIBPWNABLE"
 
 def checkInputType(binary_name):
 
+    print("[+] Checking input type")
+
     #Check for libpwnableharness
     p = angr.Project(binary_name)
     if any(['libpwnable' in str(x.binary) for x in p.loader.all_elf_objects]):

--- a/lib/overflowDetector.py
+++ b/lib/overflowDetector.py
@@ -17,6 +17,8 @@ def checkOverflow(binary_name,inputType="STDIN"):
     p.hook_symbol('rand',hookFour)
     p.hook_symbol('srand',hookFour)
 
+    hook_functions(p)
+
     #Setup state based on input type
     argv = [binary_name]
     if inputType == "STDIN":
@@ -155,3 +157,14 @@ def checkOverflow(binary_name,inputType="STDIN"):
         print("[+] Triggerable with arg : {}".format(arg_str))
 
     return run_environ
+
+def hook_functions(p):
+    if p.loader.find_symbol("gets") != None:
+        class gets(angr.SimProcedure):
+            def run(self, dst):
+                simfd = self.state.posix.files[0]
+                if simfd is None:
+                    return -1
+                return simfd.read(dst, 2**10)
+                
+        p.hook_symbol("gets", gets())

--- a/lib/overflowExploitSender.py
+++ b/lib/overflowExploitSender.py
@@ -3,6 +3,8 @@ from pwn import *
 
 def sendExploit(binary_name,properties,remote_server=False,remote_url="",port_num=0):
 
+    print("[+] start exploiting")
+    
     send_results = {}
 
     #Create local or remote process

--- a/lib/overflowExploiter.py
+++ b/lib/overflowExploiter.py
@@ -56,6 +56,7 @@ def getRopchain(properties,bad_bytes):
     #If you were looking for good programming examples, you've
     #come to the wrong place friend
     chain = rs.createRopChain("execve",arch,{'cmd':'/bin/sh'})
+    chain = chain.replace("print rop","")
 
     if "Cannot create chain" in chain or 'INSERT' in chain:
         print("[-] Failed to create rop chain. Try adding linked libraries")
@@ -113,6 +114,8 @@ def getShellcode(properties):
 
 def exploitOverflow(binary_name, properties, inputType="STDIN"):
 
+    print("[+] start exploiting symbolically")
+
     #p = angr.Project(binary_name,load_options={"auto_load_libs": False})
     class hookFour(angr.SimProcedure):
         IS_FUNCTION = True
@@ -123,6 +126,8 @@ def exploitOverflow(binary_name, properties, inputType="STDIN"):
     extras = {so.REVERSE_MEMORY_NAME_MAP, so.TRACK_ACTION_HISTORY}
     p.hook_symbol('rand',hookFour)
     p.hook_symbol('srand',hookFour)
+
+    hook_functions(p)
 
     #Setup state based on input type
     argv = [binary_name]
@@ -144,7 +149,7 @@ def exploitOverflow(binary_name, properties, inputType="STDIN"):
         register_names = state.arch.register_names.values()
         for register in register_names:
             if register in reg_values: #Didn't use the register
-                state.registers.store(register,reg_values[register])
+                state.registers.store(register, reg_values[register])
 
     else:
         arg = claripy.BVS("arg1", 100 * 8)
@@ -773,10 +778,9 @@ def find_symbolic_buffer(state, length, arg=None):
             yield addr
 def getRegValues(filename,endAddr):
 
-    r2 = r2pipe.open(filename)
-    r2.cmd('doo')
+    r2 = r2pipe.open(filename, flags=['-d'])
     r2.cmd('dcu {}'.format(endAddr))
-    regs = json.loads(r2.cmd('drj'))
+    regs = json.loads(r2.cmd('drrj'))
     r2.quit()
     return regs
 
@@ -786,7 +790,7 @@ It's also only for stdin
 '''
 def findShellcode(filename,endAddr,shellcode,commandInput):
 
-    hex_str = shellcode[:4].encode('hex')
+    hex_str = shellcode[:8].encode('hex')
 
     abs_path = os.path.abspath(filename)
 
@@ -798,7 +802,6 @@ def findShellcode(filename,endAddr,shellcode,commandInput):
     with open('temp.rr2','w') as f:
         f.write("program={}\nstdin=command.input\nenvfile={}\n".format(filename,"temp.env"))
 #        f.write("program={}\nstdin=command.input\nclearenv=true\nenvfile={}\n".format(abs_path,"temp.env"))
-
 
     r2 = r2pipe.open(filename)
     r2.cmd('e dbg.profile = temp.rr2')
@@ -819,3 +822,14 @@ def findShellcode(filename,endAddr,shellcode,commandInput):
 
 
     return loc
+
+def hook_functions(p):
+    if p.loader.find_symbol("gets") != None:
+        class gets(angr.SimProcedure):
+            def run(self, dst):
+                simfd = self.state.posix.files[0]
+                if simfd is None:
+                    return -1
+                return simfd.read(dst, 2**10)
+                
+        p.hook_symbol("gets", gets())


### PR DESCRIPTION
- Specify the version number for each python package, which should prevent dependency problems in the future.

- Fix a radare2 problem as in version 5.1.0 the command “drj” is no longer supported and “drrj” should be used as a replacement. Also make changes to install script to build a specific version of radare2 as this tool doesn’t need the latest features of radare2 and this can prevent similar issues mentioned earlier.

- Add a hook for gets to support challenges use gets.

- When executing rop build scripts generated by ropper, an error occurred in the last print statement. I could not figure out the reason so I just removed it.

- Some random patches.
