### PR TITLE
change type of shell commands to bytes

### DIFF
--- a/zeratool/formatExploiter.py
+++ b/zeratool/formatExploiter.py
@@ -760,9 +760,9 @@ def sendExploit(
 
         try:
             proc.sendline()
-            proc.sendline("ls;\n")
-            proc.sendline("cat *flag*;\n")
-            proc.sendline("cat *pass*;\n")
+            proc.sendline(b"ls;\n")
+            proc.sendline(b"cat *flag*;\n")
+            proc.sendline(b"cat *pass*;\n")
             command_results = proc.recvall(
                 timeout=30
             )  # Need a better way to "time out"

--- a/zeratool/overflowExploitSender.py
+++ b/zeratool/overflowExploitSender.py
@@ -77,9 +77,9 @@ def sendExploit(
 
     # If we have a shell, send some commands!
     proc.sendline()
-    proc.sendline("ls;\n")
-    proc.sendline("cat *flag*;\n")
-    proc.sendline("cat *pass*;\n")
+    proc.sendline(b"ls;\n")
+    proc.sendline(b"cat *flag*;\n")
+    proc.sendline(b"cat *pass*;\n")
 
     # Sometimes the flag is just printed
     results = proc.recvall(timeout=3)


### PR DESCRIPTION
We should call sendline() with byte arguments to prevent warning nags from pwntools on the console.