### PR TITLE
fix eflags crash

### DIFF
--- a/zeratool/radare_helper.py
+++ b/zeratool/radare_helper.py
@@ -19,7 +19,7 @@ def getRegValues(filename, endAddr=None):
     # drj command is broken in r2 right now
     # so use drrj
     regs = json.loads(r2.cmd("drrj"))
-    regs = dict([(x["reg"], int(x["value"], 16)) for x in regs if x["reg"] != "rflags"])
+    regs = dict([(x["reg"], int(x["value"], 16)) for x in regs if x["reg"] != "rflags" and x["reg"] != "eflags"])
     r2.quit()
     return regs
 


### PR DESCRIPTION
`eflags` can cause crashes like #22.
 I think add a `eflags` check can fix the crash.